### PR TITLE
Remplacement du terme 'Les Bacots' par lesbacots.org

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Hugo WebSite
 
-Ce dépôt est destiné à la gestion des documents du groupe "Les Bacots". Une fois relu et approuvée, le résultat est publié automatiquement sur la page github du projet.
+Ce dépôt est destiné à la gestion des documents du groupe lesbacots.org. Une fois relu et approuvée, le résultat est publié automatiquement sur la page github du projet.
 
 Toute contribution est la bienvenue. Pour plus de détails vous pouvez vous référer au [guide de contribution](CONTRIBUTING.md).
 

--- a/config/_default/params.toml
+++ b/config/_default/params.toml
@@ -1,7 +1,7 @@
 # Meta Data for SEO
 
 ## Homepage
-title = "Les Bacots"
+title = "lesbacots.org"
 titleSeparator = "-"
 titleAddition = "Le Site"
 description = ""
@@ -51,7 +51,7 @@ smallLimit = "300"
 footer = "Propulsé par <a href=\"https://gohugo.io/\">Hugo</a>, <a href=\"https://getdoks.org/\">Doks</a> et <b>Les Bacots</b>."
 
 # Feed
-copyRight = "Copyright (c) 2022 Les Bacots"
+copyRight = "Copyright (c) 2022 lesbacots.org"
 
 # Edit Page
 docsRepo = "https://github.com/les-bacots/les-bacots.github.io"

--- a/content/_index.md
+++ b/content/_index.md
@@ -1,7 +1,7 @@
 ---
 title : "lesbacots.org"
-description: "Base documentaire collaborative à disposition des bacots"
-lead: "Base documentaire collaborative à disposition des bacots"
+description: "Base documentaire collaborative à disposition des Bacots"
+lead: "Base documentaire collaborative à disposition des Bacots"
 date: 2020-10-06T08:47:36+00:00
 lastmod: 2020-10-06T08:47:36+00:00
 draft: false

--- a/content/_index.md
+++ b/content/_index.md
@@ -1,7 +1,7 @@
 ---
 title : "lesbacots.org"
-description: "Base documentaire collaborative pour les tous bacots"
-lead: "Base documentaire collaborative pour les tous bacots"
+description: "Base documentaire collaborative à disposition des bacots"
+lead: "Base documentaire collaborative à disposition des bacots"
 date: 2020-10-06T08:47:36+00:00
 lastmod: 2020-10-06T08:47:36+00:00
 draft: false

--- a/content/comment_participer/_index.md
+++ b/content/comment_participer/_index.md
@@ -11,13 +11,13 @@ images: []
 ## Le collectif lesbacots.org est ouvert à tous les habitants de Bois-le-Roi, sans exception. ##
 
 Les **lecteurs** (tout le monde) peuvent :
-- Consulter l'ensemble de la base documentaire sur www.lesbacots.org.
+- Consulter l'ensemble de la base documentaire sur lesbacots.org.
 - Voir l'ensemble des discussions du collectif sur [Discord]({{< ref "/comment_participer/discord" >}}), elles sont publiques et visibles de tous.
 - Tracer à tout moment sur https://github.com/les-bacots/les-bacots.github.io l'historique de l'ensemble des contributions et revues relatives aux contenus disponibles sur la base documentaire.
 
 Les **contributeurs** peuvent:
 - Discuter dans l'ensemble des salons de discussion du collectif à partir du moment où ils respectent les règles de discussion (ajouter le lien)
-- Editer l'ensemble des pages du site www.lesbacots.org à partir du moment où ils respectent la charte de contribution (ajouter le lien).
+- Editer l'ensemble des pages du site lesbacots.org à partir du moment où ils respectent la charte de contribution (ajouter le lien).
 
 ## Comment devenir contributeur ?
 Pour avoir le droit de discuter sur les salons Discord ou de contribuer sur la base documentaire, il faut devenir **Contributeur**

--- a/content/comment_participer/_index.md
+++ b/content/comment_participer/_index.md
@@ -1,14 +1,14 @@
 ---
 title : "Comment participer ?"
-description: "Description des droits et devoirs pour devenir contributeur"
-lead: "Description des droits et devoirs pour devenir contributeur"
+description: "Description des droits et devoirs pour devenir contributeur sur lesbacots.org"
+lead: "Description des droits et devoirs pour devenir contributeur sur lesbacots.org"
 date: 2020-10-06T08:48:23+00:00
 lastmod: 2020-10-06T08:48:23+00:00
 draft: false
 images: []
 ---
 
-## Le collectif "Les Bacots" est ouvert à tous les habitants de Bois-le-Roi, sans exception. ##
+## Le collectif lesbacots.org est ouvert à tous les habitants de Bois-le-Roi, sans exception. ##
 
 Les **lecteurs** (tout le monde) peuvent :
 - Consulter l'ensemble de la base documentaire sur www.lesbacots.org.

--- a/content/groupes_de_travail/_index.md
+++ b/content/groupes_de_travail/_index.md
@@ -10,7 +10,7 @@ toc: true
 weight: 130
 ---
 
-Les *groupes de travail* regroupent des contributeurs du collectif "Les Bacots" qui s'intéressent à des grandes problématiques identifiées.
+Les *groupes de travail* regroupent des contributeurs du collectif lesbacots.org qui s'intéressent à des grandes problématiques identifiées.
 La liste des groupes de travail est succeptible d'évoluer en fonction des sujets d'intérêts proposés par les membres du collectif.
 
 Chaque *groupe de travail* est organisé à la manière d'un *wiki* sur lequel tous les membres contributeurs du collectif peuvent contribuer.

--- a/content/membres/_index.md
+++ b/content/membres/_index.md
@@ -1,7 +1,7 @@
 ---
 title: "Membres"
-description: "Contributeurs sur la base documentaire www.lesbacots.org"
-lead: "Contributeurs sur la base documentaire www.lesbacots.org"
+description: "Contributeurs sur la base documentaire lesbacots.org"
+lead: "Contributeurs sur la base documentaire lesbacots.org"
 date: 2020-10-06T08:50:29+00:00
 lastmod: 2020-10-06T08:50:29+00:00
 draft: false

--- a/content/membres/florent.md
+++ b/content/membres/florent.md
@@ -1,7 +1,7 @@
 ---
 title: "Florent Pigout"
-description: "Référent 'Les Bacots'"
-lead: "Référent 'Les Bacots'"
+description: "Référent lesbacots.org"
+lead: "Référent lesbacots.org"
 date: 2021-01-11T21:21:01+02:00
 lastmod: 2021-01-11T21:21:01+02:00
 draft: false

--- a/content/membres/margaux.md
+++ b/content/membres/margaux.md
@@ -1,7 +1,7 @@
 ---
 title: "Margaux de Roquefeuil"
-description: "Référente 'Les Bacots'"
-lead: "Référente 'Les Bacots'"
+description: "Référente lesbacots.org"
+lead: "Référente lesbacots.org"
 date: 2021-01-11T21:21:01+02:00
 lastmod: 2021-01-11T21:21:01+02:00
 draft: false

--- a/content/membres/pierrick.md
+++ b/content/membres/pierrick.md
@@ -1,7 +1,7 @@
 ---
 title: "Pierrick Houdeville"
-description: "Référent 'Les Bacots'"
-lead: "Référent 'Les Bacots'"
+description: "Référent lesbacots.org"
+lead: "Référent lesbacots.org"
 date: 2021-01-11T21:21:01+02:00
 lastmod: 2021-01-11T21:21:01+02:00
 draft: false

--- a/content/membres/simon.md
+++ b/content/membres/simon.md
@@ -32,7 +32,7 @@ toc: true
 - J'ai exprimé mes questions et réserves sur la modification n°3 du PLU dans le cadre de l'enquête publique et rencontré le commissaire enquêteur à cette occasion.
 - J'ai aidé l'association "Bien à Bois-le-Roi" à collecter des fonds en organisant la collecte de crowdfunding sur HelloAsso (https://www.helloasso.com/associations/bien-a-bois-le-roi/collectes/collecte-1-bien-a-bois-le-roi) et soutenu en tant que donnateur.
 - Je suis membre d'aucune association sur Bois-le-Roi.
-- Je suis membre-fondateur du collectif "Les Bacots".
+- Je suis membre du collectif lesbacots.org.
 
 ### Ma profession actuelle
 

--- a/content/membres/simon.md
+++ b/content/membres/simon.md
@@ -1,7 +1,7 @@
 ---
 title: "Simon Mencarelli"
-description: "Référent 'Les Bacots'"
-lead: "Référent 'Les Bacots'"
+description: "Référent lesbacots.org"
+lead: "Référent lesbacots.org"
 date: 2021-01-11T21:21:01+02:00
 lastmod: 2021-01-11T21:21:01+02:00
 draft: false

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "website",
-  "description": "Website pour 'les bacots'",
+  "name": "lesbacots.org",
+  "description": "Base documentaire lesbacots.org",
   "version": "0.1.0",
   "browserslist": [
     "defaults"


### PR DESCRIPTION
on désigne le collectif par lesbacots.org partout sur le site